### PR TITLE
fix(tests): isolate cwd in CLI fixture to prevent project-scope leakage

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -16,7 +16,7 @@ def runner():
 
 
 @pytest.fixture
-def isolated_env(tmp_path):
+def isolated_env(tmp_path, monkeypatch):
     """Create an isolated environment for CLI tests."""
     home = tmp_path / "home"
     home.mkdir()
@@ -24,6 +24,12 @@ def isolated_env(tmp_path):
 
     # Create agent directories so auto-detect works
     (home / ".claude").mkdir()
+
+    # Chdir into a sandbox so commands that resolve project scope via Path.cwd()
+    # (e.g. `add --project`) don't write into the real repo.
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
 
     env = {
         "HOME": str(home),


### PR DESCRIPTION
## Summary
- `isolated_env` fixture now chdirs into a tmp sandbox so `add --project` (which resolves project root via `Path.cwd()` in `src/napoln/cli.py:78`) doesn't write into the real repo's `.claude/` during test runs.
- Discovered after finding leaked `test-skill` and `napoln-manage` directories under `.claude/skills/` whose `.napoln` `source` pointed at a `pytest` tmpdir from `test_add_with_project`.

## Test plan
- [x] `uv run pytest tests/integration/test_cli.py` (30 passed)
- [ ] Confirm no new artifacts appear under `.claude/skills/` after a full test run