### PR TITLE
feat: add `napoln setup` to choose default agents

### DIFF
--- a/src/napoln/cli.py
+++ b/src/napoln/cli.py
@@ -233,6 +233,23 @@ def init(
     raise typer.Exit(code=exit_code)
 
 
+# ─── setup ────────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def setup(
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Re-run setup even if default agents are already configured."),
+    ] = False,
+) -> None:
+    """Choose which agents `napoln add` should install to by default."""
+    from napoln.commands.setup import run_setup
+
+    exit_code = run_setup(force=force)
+    raise typer.Exit(code=exit_code)
+
+
 # ─── config ───────────────────────────────────────────────────────────────────
 
 

--- a/src/napoln/commands/add.py
+++ b/src/napoln/commands/add.py
@@ -349,9 +349,12 @@ def run_add(
     else:
         resolved_list = [resolved_result]
 
-    # Detect agents
+    # Detect agents — prefer configured defaults over auto-detection
+    default_agent_ids = agents_mod.load_default_agent_ids(napoln_home)
     try:
-        agent_configs = agents_mod.resolve_agents(agent_ids, home, project_root, scope)
+        agent_configs = agents_mod.resolve_agents(
+            agent_ids, home, project_root, scope, default_agent_ids=default_agent_ids
+        )
     except ValueError as e:
         output.error(str(e))
         return 1
@@ -362,6 +365,14 @@ def run_add(
             fix="Specify agents with --agents, e.g.:\n  napoln add <source> --agents claude-code,pi",
         )
         return 1
+
+    # If the user has multiple agents installed but never configured defaults,
+    # nudge them toward `napoln setup` so they don't keep spray-installing.
+    if agent_ids is None and not default_agent_ids and scope == "global" and len(agent_configs) > 1:
+        output.info(
+            f"Installing to all {len(agent_configs)} detected agents. "
+            "Run `napoln setup` to choose defaults."
+        )
 
     if dry_run:
         output.dry_run_header()

--- a/src/napoln/commands/setup.py
+++ b/src/napoln/commands/setup.py
@@ -1,0 +1,102 @@
+"""napoln setup — One-time interactive onboarding to choose default agents."""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+from napoln import output
+from napoln.core import agents as agents_mod
+from napoln.prompts import pick_agents
+
+
+def _get_napoln_home() -> Path:
+    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
+
+
+def _ensure_initialized(napoln_home: Path) -> None:
+    napoln_home.mkdir(parents=True, exist_ok=True)
+    (napoln_home / "store").mkdir(exist_ok=True)
+    (napoln_home / "cache").mkdir(exist_ok=True)
+
+
+def _load_config(config_path: Path) -> dict:
+    if not config_path.exists():
+        return {}
+    try:
+        return tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def _write_default_agents(config_path: Path, agent_ids: list[str]) -> None:
+    data = _load_config(config_path)
+    section = data.setdefault("napoln", {})
+    section["default_agents"] = agent_ids
+    section.setdefault("default_scope", "global")
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(tomli_w.dumps(data), encoding="utf-8")
+
+
+def run_setup(force: bool = False) -> int:
+    """Run the interactive onboarding wizard.
+
+    Detects available agents, prompts the user to pick defaults, and persists
+    the selection to ``[napoln].default_agents`` in ``~/.napoln/config.toml``.
+
+    Args:
+        force: Re-run even if defaults are already configured.
+
+    Returns:
+        Exit code (0 on success, 1 on cancel/error).
+    """
+    napoln_home = _get_napoln_home()
+    home = Path(os.environ.get("HOME", Path.home()))
+    config_path = napoln_home / "config.toml"
+
+    _ensure_initialized(napoln_home)
+
+    existing = agents_mod.load_default_agent_ids(napoln_home)
+    if existing and not force:
+        names = ", ".join(agents_mod.AGENTS[aid].display_name for aid in existing)
+        output.info(f"Default agents already configured: {names}")
+        output.info("Re-run with --force to change them.")
+        return 0
+
+    detected = agents_mod.detect_agents(home)
+    if not detected:
+        output.error(
+            "No agents detected on this machine.",
+            fix=(
+                "Install one of: Claude Code, Gemini CLI, pi, Codex, Cursor — "
+                "then re-run `napoln setup`."
+            ),
+        )
+        return 1
+
+    output.header("napoln setup")
+    output.info(f"Detected {len(detected)} agent(s) on this machine.")
+
+    preselected = existing or [a.id for a in detected]
+    selected = pick_agents(detected, preselected_ids=preselected)
+
+    if selected is None:
+        output.warning("Setup cancelled.")
+        return 1
+
+    if not selected:
+        output.warning("No agents selected — defaults will not be saved.")
+        return 1
+
+    selected_ids = [a.id for a in selected]
+    _write_default_agents(config_path, selected_ids)
+
+    names = ", ".join(a.display_name for a in selected)
+    output.success(f"Saved default agents: {names}")
+    output.info(f"Wrote {config_path}")
+    output.info("Future `napoln add` commands will install to these agents by default.")
+    output.info("Override per-command with `--agents <id1,id2,...>`.")
+    return 0

--- a/src/napoln/commands/setup.py
+++ b/src/napoln/commands/setup.py
@@ -80,8 +80,10 @@ def run_setup(force: bool = False) -> int:
     output.header("napoln setup")
     output.info(f"Detected {len(detected)} agent(s) on this machine.")
 
-    preselected = existing or [a.id for a in detected]
-    selected = pick_agents(detected, preselected_ids=preselected)
+    # Only preselect agents already in config; on first run the list is empty
+    # so the user has to actively pick — having a tool installed is not the
+    # same as wanting skills installed into it.
+    selected = pick_agents(detected, preselected_ids=existing)
 
     if selected is None:
         output.warning("Setup cancelled.")

--- a/src/napoln/core/agents.py
+++ b/src/napoln/core/agents.py
@@ -6,6 +6,7 @@ Supports: Claude Code, Gemini CLI, pi, Codex, Cursor.
 from __future__ import annotations
 
 import shutil
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -137,22 +138,52 @@ def detect_agents(
     return detected
 
 
+def load_default_agent_ids(napoln_home: Path) -> list[str]:
+    """Read configured default_agents from napoln config.toml.
+
+    Returns an empty list if the config does not exist or has no defaults set.
+    Unknown agent IDs are silently dropped (the config command validates input,
+    but a config file edited by hand may contain stale entries).
+    """
+    config_path = napoln_home / "config.toml"
+    if not config_path.exists():
+        return []
+    try:
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    raw = data.get("napoln", {}).get("default_agents", [])
+    if not isinstance(raw, list):
+        return []
+    return [aid for aid in raw if isinstance(aid, str) and aid in AGENTS]
+
+
 def resolve_agents(
-    agent_ids: list[str] | None, home: Path, project_root: Path | None = None, scope: str = "global"
+    agent_ids: list[str] | None,
+    home: Path,
+    project_root: Path | None = None,
+    scope: str = "global",
+    default_agent_ids: list[str] | None = None,
 ) -> list[AgentConfig]:
-    """Resolve agent list from explicit IDs or auto-detection.
+    """Resolve agent list from explicit IDs, configured defaults, or auto-detection.
+
+    Resolution order:
+        1. Explicit ``agent_ids`` (e.g., from ``--agents`` flag).
+        2. ``default_agent_ids`` (e.g., from ``[napoln].default_agents`` in config.toml).
+        3. Auto-detection of installed agents.
 
     Args:
-        agent_ids: Explicit agent IDs, or None for auto-detect.
+        agent_ids: Explicit agent IDs, or None to fall through to defaults/auto-detect.
         home: User home directory.
         project_root: Project root (for project-scope).
         scope: "global" or "project".
+        default_agent_ids: Configured defaults to prefer over auto-detection.
 
     Returns:
         List of AgentConfig objects.
 
     Raises:
-        ValueError: If an unknown agent ID is specified.
+        ValueError: If an unknown agent ID is specified in ``agent_ids``.
     """
     if agent_ids:
         configs = []
@@ -161,6 +192,9 @@ def resolve_agents(
                 raise ValueError(f"Unknown agent: {aid}. Available: {', '.join(AGENTS.keys())}")
             configs.append(AGENTS[aid])
         return configs
+
+    if default_agent_ids:
+        return [AGENTS[aid] for aid in default_agent_ids if aid in AGENTS]
 
     return detect_agents(home, project_root, scope)
 

--- a/src/napoln/prompts.py
+++ b/src/napoln/prompts.py
@@ -6,6 +6,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from napoln.core.agents import AgentConfig
+
 
 @dataclass
 class SkillChoice:
@@ -107,5 +109,60 @@ def pick_skills(choices: list[SkillChoice]) -> list[SkillChoice]:
     if selected is None:
         # User pressed ctrl-c
         return []
+
+    return selected
+
+
+def pick_agents(
+    available: list[AgentConfig],
+    preselected_ids: list[str] | None = None,
+) -> list[AgentConfig] | None:
+    """Interactive checkbox picker for agents.
+
+    Returns the selected agents, or None if the user cancelled (ctrl-c).
+    Returns an empty list if the user confirmed with nothing selected.
+
+    Falls back to selecting all available agents in non-TTY environments so
+    automation does not hang.
+    """
+    if not available:
+        return []
+
+    if not sys.stdin.isatty():
+        return list(available)
+
+    import questionary
+    from questionary import constants as q_constants
+    from questionary.prompts import common as q_common
+
+    q_constants.INDICATOR_SELECTED = "✓"
+    q_constants.INDICATOR_UNSELECTED = " "
+    q_common.INDICATOR_SELECTED = "✓"
+    q_common.INDICATOR_UNSELECTED = " "
+
+    preselected = set(preselected_ids or [])
+    max_name = max(len(a.display_name) for a in available)
+
+    options = []
+    for agent in available:
+        tokens: list[tuple[str, str]] = [
+            ("class:text", f"{agent.display_name:<{max_name}}"),
+            ("class:text", f"  ({agent.id})"),
+        ]
+        options.append(
+            questionary.Choice(
+                title=tokens,
+                value=agent,
+                checked=agent.id in preselected,
+            )
+        )
+
+    style = questionary.Style([("selected", "noreverse")])
+
+    selected = questionary.checkbox(
+        "Select default agents (skills will install to these unless overridden):",
+        choices=options,
+        style=style,
+    ).ask()
 
     return selected

--- a/src/napoln/prompts.py
+++ b/src/napoln/prompts.py
@@ -160,7 +160,7 @@ def pick_agents(
     style = questionary.Style([("selected", "noreverse")])
 
     selected = questionary.checkbox(
-        "Select default agents (skills will install to these unless overridden):",
+        "Default agents:",
         choices=options,
         style=style,
     ).ask()

--- a/tests/features/setup.feature
+++ b/tests/features/setup.feature
@@ -1,0 +1,30 @@
+Feature: Choose default agents
+  As a developer with multiple AI coding tools installed
+  I want to pick which agents napoln installs to by default
+  So that `napoln add` does not spray skills across every detected tool
+
+  Scenario: Setup persists default agents to config
+    Given Claude Code and Cursor are installed
+    When I run napoln setup with selection "claude-code"
+    Then the config contains default_agents "claude-code"
+    And the exit code is 0
+
+  Scenario: Add respects configured default agents
+    Given Claude Code and Cursor are installed
+    And default_agents is configured to "claude-code"
+    When I run napoln add with a valid local skill
+    Then the skill is placed only for Claude Code
+    And the exit code is 0
+
+  Scenario: Add hints at setup when defaults are unset and multiple agents detected
+    Given Claude Code and Cursor are installed
+    And default_agents is not configured
+    When I run napoln add with a valid local skill
+    Then the output contains "napoln setup"
+    And the exit code is 0
+
+  Scenario: Setup with no agents detected fails with guidance
+    Given no agents are installed
+    When I run napoln setup non-interactively
+    Then the output contains "No agents detected"
+    And the exit code is 1

--- a/tests/steps/test_setup.py
+++ b/tests/steps/test_setup.py
@@ -1,0 +1,130 @@
+"""Step definitions for setup.feature."""
+
+from __future__ import annotations
+
+import tomllib
+
+import tomli_w
+from pytest_bdd import given, parsers, scenario, then, when
+from typer.testing import CliRunner
+
+from napoln.cli import app
+from tests.steps.conftest import NapolnTestEnv
+
+
+@scenario("../features/setup.feature", "Setup persists default agents to config")
+def test_setup_persists_defaults():
+    pass
+
+
+@scenario("../features/setup.feature", "Add respects configured default agents")
+def test_add_respects_defaults():
+    pass
+
+
+@scenario(
+    "../features/setup.feature",
+    "Add hints at setup when defaults are unset and multiple agents detected",
+)
+def test_add_hints_at_setup():
+    pass
+
+
+@scenario("../features/setup.feature", "Setup with no agents detected fails with guidance")
+def test_setup_no_agents():
+    pass
+
+
+# ─── Given ────────────────────────────────────────────────────────────────────
+
+
+@given("Claude Code and Cursor are installed", target_fixture="env")
+def claude_and_cursor(napoln_env: NapolnTestEnv, monkeypatch):
+    (napoln_env.home / ".claude").mkdir(parents=True, exist_ok=True)
+    (napoln_env.home / ".cursor").mkdir(parents=True, exist_ok=True)
+    # Don't let pi/codex on the real PATH leak into detection.
+    monkeypatch.setattr("napoln.core.agents._check_on_path", lambda cmd: False)
+    return napoln_env
+
+
+@given("no agents are installed", target_fixture="env")
+def no_agents(napoln_env: NapolnTestEnv, monkeypatch):
+    monkeypatch.setattr("napoln.core.agents._check_on_path", lambda cmd: False)
+    return napoln_env
+
+
+@given(parsers.parse('default_agents is configured to "{ids}"'))
+def configure_defaults(env: NapolnTestEnv, ids: str):
+    env.napoln_home.mkdir(parents=True, exist_ok=True)
+    config_path = env.napoln_home / "config.toml"
+    data = {"napoln": {"default_agents": [a.strip() for a in ids.split(",")]}}
+    config_path.write_text(tomli_w.dumps(data))
+
+
+@given("default_agents is not configured")
+def no_defaults(env: NapolnTestEnv):
+    config_path = env.napoln_home / "config.toml"
+    assert not config_path.exists()
+
+
+# ─── When ────────────────────────────────────────────────────────────────────
+
+
+@when(parsers.parse('I run napoln setup with selection "{ids}"'), target_fixture="result_env")
+def run_setup_with_selection(env: NapolnTestEnv, ids: str, cli_runner: CliRunner, monkeypatch):
+    from napoln.core import agents as agents_mod
+
+    selected_ids = [a.strip() for a in ids.split(",")]
+    selected = [agents_mod.AGENTS[aid] for aid in selected_ids]
+    # Bypass the questionary prompt: return the chosen agents directly.
+    monkeypatch.setattr(
+        "napoln.commands.setup.pick_agents", lambda available, preselected_ids=None: selected
+    )
+    env.result = cli_runner.invoke(app, ["setup"], env=env.env_vars)
+    return env
+
+
+@when("I run napoln setup non-interactively", target_fixture="result_env")
+def run_setup_noninteractive(env: NapolnTestEnv, cli_runner: CliRunner):
+    env.result = cli_runner.invoke(app, ["setup"], env=env.env_vars)
+    return env
+
+
+@when("I run napoln add with a valid local skill", target_fixture="result_env")
+def run_add(env: NapolnTestEnv, cli_runner: CliRunner):
+    skill_path = env.create_local_skill()
+    env.result = cli_runner.invoke(app, ["add", str(skill_path)], env=env.env_vars)
+    return env
+
+
+# ─── Then ────────────────────────────────────────────────────────────────────
+
+
+@then(parsers.parse('the config contains default_agents "{ids}"'))
+def config_has_defaults(result_env: NapolnTestEnv, ids: str):
+    config_path = result_env.napoln_home / "config.toml"
+    assert config_path.exists(), "config.toml was not written"
+    data = tomllib.loads(config_path.read_text())
+    expected = [a.strip() for a in ids.split(",")]
+    assert data["napoln"]["default_agents"] == expected
+
+
+@then("the skill is placed only for Claude Code")
+def placed_only_for_claude(result_env: NapolnTestEnv):
+    claude_skill = result_env.home / ".claude" / "skills" / "test-skill"
+    cursor_skill = result_env.home / ".cursor" / "skills" / "test-skill"
+    assert claude_skill.exists(), f"Expected Claude placement at {claude_skill}"
+    assert not cursor_skill.exists(), f"Did not expect Cursor placement at {cursor_skill}"
+
+
+@then(parsers.parse('the output contains "{text}"'))
+def output_contains(result_env: NapolnTestEnv, text: str):
+    combined = result_env.result.output + (result_env.result.stderr or "")
+    assert text in combined, f"Expected '{text}' in:\n{combined}"
+
+
+@then(parsers.parse("the exit code is {code:d}"))
+def check_exit_code(result_env: NapolnTestEnv, code: int):
+    assert result_env.result.exit_code == code, (
+        f"exit={result_env.result.exit_code} output={result_env.result.output!r}"
+    )


### PR DESCRIPTION
## Summary
- New `napoln setup` interactive wizard persists `[napoln].default_agents` to `~/.napoln/config.toml`
- `resolve_agents()` now prefers configured defaults over auto-detection (auto-detect remains the fallback)
- `napoln add` prints a one-line hint pointing at `napoln setup` when defaults are unset and a global install would hit >1 detected agent

## Why
Without defaults configured, `napoln add raiderrobert/sauce` spray-installs to every detected tool (Claude Code, Gemini CLI, pi, Codex, Cursor). Users with multiple agents installed expect to opt into a default set once.

## Test plan
- [x] `tests/features/setup.feature` — 4 BDD scenarios: persistence, add respects defaults, hint shown, no-agents error
- [x] Full suite passes (1 unrelated pre-existing failure in `test_upgrade.py::test_script_replaced`)
- [x] Manual: `napoln setup` on a machine with all 5 agents installed; verify subsequent `napoln add` only hits the chosen subset