### PR TITLE
feat(remove): accept multiple names and --from-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,30 @@ napoln upgrade code-review
 # ✓ Merged 'code-review' at ~/.claude/skills/code-review (2 files updated)
 ```
 
+Remove one or more skills at once:
+
+```bash
+napoln remove design-audit design-frontend design-preflight
+```
+
+Remove all skills from a specific repository:
+
+```bash
+napoln remove --from-source raiderrobert/flow
+```
+
+Combine explicit names with `--from-source` filter:
+
+```bash
+napoln remove --from-source raiderrobert/flow design-audit
+```
+
 ## Commands
 
 ```
 napoln add <source>           Install skills from a git repo or local path
-napoln remove <name>          Remove an installed skill
+napoln remove <name>...       Remove one or more skills
+napoln remove --from-source  Remove all skills from a specific repository
 napoln upgrade [<name>]       Upgrade one or all skills
 napoln list                   Show installed skills and where they are placed
 napoln install                Restore skill placements from manifests

--- a/src/napoln/cli.py
+++ b/src/napoln/cli.py
@@ -98,7 +98,14 @@ def add(
 
 @app.command()
 def remove(
-    name: Annotated[str, typer.Argument(help="Skill name to remove.")],
+    name: Annotated[list[str], typer.Argument(help="Skill name(s) to remove.")] = [],
+    from_source: Annotated[
+        Optional[str],
+        typer.Option(
+            "--from-source",
+            help="Remove all skills from this repository (e.g., raiderrobert/flow or https://github.com/owner/repo).",
+        ),
+    ] = None,
     project: Annotated[
         bool, typer.Option("--project", "-p", help="Remove from project scope.")
     ] = False,
@@ -107,7 +114,7 @@ def remove(
     ] = None,
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Show what would happen.")] = False,
 ) -> None:
-    """Remove an installed skill."""
+    """Remove one or more installed skills."""
     from napoln.commands.remove import run_remove
 
     agent_ids = [a.strip() for a in agents.split(",")] if agents else None
@@ -115,7 +122,8 @@ def remove(
     project_root = Path.cwd() if project else None
 
     exit_code = run_remove(
-        name=name,
+        names=name,
+        from_source=from_source,
         agent_ids=agent_ids,
         scope=scope,
         project_root=project_root,

--- a/src/napoln/commands/remove.py
+++ b/src/napoln/commands/remove.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from napoln import output
 from napoln.core import manifest
+from napoln.core.resolver import normalize_source_for_match
 
 
 def _get_napoln_home() -> Path:
@@ -15,14 +16,47 @@ def _get_napoln_home() -> Path:
     return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
 
 
+def _resolve_from_source(
+    from_source: str,
+    mf: manifest.Manifest,
+) -> list[str]:
+    """Resolve --from-source to matching skill names.
+
+    Args:
+        from_source: Source identifier (shorthand or URL).
+        mf: Current manifest.
+
+    Returns:
+        List of skill names that match the source.
+    """
+    normalized = normalize_source_for_match(from_source)
+    matching_names: list[str] = []
+
+    for name, entry in mf.skills.items():
+        entry_source = normalize_source_for_match(entry.source)
+        if entry_source == normalized:
+            matching_names.append(name)
+
+    return matching_names
+
+
 def run_remove(
-    name: str,
+    names: list[str],
+    from_source: str | None = None,
     agent_ids: list[str] | None = None,
     scope: str = "global",
     project_root: Path | None = None,
     dry_run: bool = False,
 ) -> int:
     """Execute the remove command.
+
+    Args:
+        names: Skill names to remove.
+        from_source: If set, remove all skills from this repository.
+        agent_ids: If specified, only remove these agent placements.
+        scope: "global" or "project".
+        project_root: Project root for project scope.
+        dry_run: Show what would happen without applying.
 
     Returns:
         Exit code (0=success, 1=error).
@@ -31,14 +65,63 @@ def run_remove(
     manifest_path = manifest.get_manifest_path(napoln_home, scope, project_root)
     mf = manifest.read_manifest(manifest_path)
 
+    # Resolve --from-source to names and merge with explicit names
+    from_source_names = []
+    if from_source:
+        from_source_names = _resolve_from_source(from_source, mf)
+        if not from_source_names:
+            output.info(f"No skills found from '{from_source}'.")
+        # Merge with explicit names, avoid duplicates
+        existing = set(from_source_names)
+        for name in names:
+            if name not in existing:
+                from_source_names.append(name)
+        names = from_source_names
+
+    if not names:
+        output.info("No skills specified.")
+        return 0
+
+    if dry_run:
+        output.dry_run_header()
+
+    exit_code = 0
+
+    for name in names:
+        result = _remove_single(
+            name=name,
+            mf=mf,
+            manifest_path=manifest_path,
+            agent_ids=agent_ids,
+            dry_run=dry_run,
+        )
+        if result != 0:
+            exit_code = 1
+
+    if not dry_run:
+        # Write manifest once after all removals
+        manifest.write_manifest(mf, manifest_path)
+
+    return exit_code
+
+
+def _remove_single(
+    name: str,
+    mf: manifest.Manifest,
+    manifest_path: Path,
+    agent_ids: list[str] | None,
+    dry_run: bool,
+) -> int:
+    """Remove a single skill from manifest and filesystem.
+
+    Returns:
+        0 on success, 1 on error.
+    """
     if name not in mf.skills:
         output.info(f"'{name}' is not installed.")
         return 0
 
     entry = mf.skills[name]
-
-    if dry_run:
-        output.dry_run_header()
 
     # Determine which agents to remove
     agents_to_remove = agent_ids if agent_ids else list(entry.agents.keys())
@@ -60,13 +143,10 @@ def run_remove(
                 output.dim(f"  Placement already gone: {placement_path}")
 
     if dry_run:
-        output.would("update manifest")
-        output.dry_run_footer()
         return 0
 
-    # Update manifest
+    # Update manifest - remove skill or just the agent placements
     mf = manifest.remove_skill_from_manifest(mf, name, agent_ids)
-    manifest.write_manifest(mf, manifest_path)
     output.success(f"Removed '{name}'")
 
     return 0

--- a/src/napoln/core/resolver.py
+++ b/src/napoln/core/resolver.py
@@ -543,3 +543,45 @@ def discover_skill_choices(repo_dir: Path) -> list[tuple[str, str, Path]]:
         desc = _extract_description(skill_dir)
         results.append((name, desc, skill_dir))
     return results
+
+
+def normalize_source_for_match(source: str) -> str:
+    """Normalize a source identifier for matching against manifest entries.
+
+    - Strips https://github.com/ prefix and .git suffix from full URLs
+    - Converts GitHub shorthand (owner/repo) to normalized form
+    - Returns local paths unchanged
+
+    Args:
+        source: Source identifier (URL, shorthand, or local path).
+
+    Returns:
+        Normalized source identifier for matching.
+    """
+    # Strip .git suffix
+    if source.endswith(".git"):
+        source = source[:-4]
+
+    # Strip URL scheme
+    if source.startswith("https://"):
+        source = source[8:]
+    elif source.startswith("http://"):
+        source = source[7:]
+    elif source.startswith("git@"):
+        # git@github.com:owner/repo -> github.com/owner/repo
+        source = source[4:].replace(":", "/")
+
+    # Check if already normalized (has host with domain, e.g. github.com/owner/repo)
+    # vs shorthand (owner/repo) which needs normalization
+    if "/" in source:
+        first_segment = source.split("/")[0]
+        # If first segment has a dot, it's likely a host (already normalized)
+        if "." in first_segment:
+            return source
+
+    # GitHub shorthand: owner/repo -> github.com/owner/repo
+    parsed = parse_source(source)
+    if parsed.source_type == "git" and parsed.host:
+        return f"{parsed.host}/{parsed.owner}/{parsed.repo}"
+
+    return source

--- a/src/napoln/skills/napoln-manage/SKILL.md
+++ b/src/napoln/skills/napoln-manage/SKILL.md
@@ -24,7 +24,7 @@ runs. Use `uvx` to invoke it without relying on PATH:
 uvx napoln add owner/repo            # add (preferred — no PATH dependency)
 uvx napoln list                     # list
 uvx napoln upgrade                  # upgrade
-uvx napoln remove <name>            # remove
+uvx napoln remove <name>...       # remove (or --from-source)
 uvx napoln install                  # sync from manifests
 uvx napoln init my-skill            # scaffold a new skill
 uvx napoln config doctor            # verify integrity
@@ -69,8 +69,22 @@ upstream also changed the same lines):
 
 ## Remove a Skill
 
+Remove one or more skills:
+
 ```bash
-uvx napoln remove <name>
+uvx napoln remove design-audit design-frontend design-preflight
+```
+
+Remove all skills from a specific repository:
+
+```bash
+uvx napoln remove --from-source raiderrobert/flow
+```
+
+Combine explicit names with `--from-source` filter:
+
+```bash
+uvx napoln remove --from-source raiderrobert/flow design-audit
 ```
 
 ## Scaffold a New Skill

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -279,9 +279,7 @@ class TestRemoveCommand:
         runner.invoke(app, ["add", str(skill_b)], env=env)
 
         # Remove skill-a explicitly and skill-b via from-source
-        result = runner.invoke(
-            app, ["remove", "skill-a", "--from-source", "raiderrobert/other"], env=env
-        )
+        runner.invoke(app, ["remove", "skill-a", "--from-source", "raiderrobert/other"], env=env)
         # skill-a should be removed, skill-b stays (no match)
         assert not (home / ".claude" / "skills" / "skill-a").exists()
         assert (home / ".claude" / "skills" / "skill-b").exists()

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+import tomli_w
 from typer.testing import CliRunner
 
 from napoln.cli import app
@@ -185,6 +186,105 @@ class TestRemoveCommand:
         assert "Dry run" in result.output
         # Skill should still be placed
         assert (home / ".claude" / "skills" / "test-skill" / "SKILL.md").exists()
+
+    def test_remove_multiple_names(self, runner, isolated_env, tmp_path):
+        """Remove multiple skills at once."""
+        home, napoln_home, env = isolated_env
+
+        # Add first skill
+        skill1 = tmp_path / "skill-one"
+        skill1.mkdir()
+        (skill1 / "SKILL.md").write_text(
+            "---\nname: skill-one\ndescription: First skill.\n"
+            'metadata:\n  version: "1.0.0"\n---\n\n# Skill One\n'
+        )
+        runner.invoke(app, ["add", str(skill1)], env=env)
+
+        # Add second skill
+        skill2 = tmp_path / "skill-two"
+        skill2.mkdir()
+        (skill2 / "SKILL.md").write_text(
+            "---\nname: skill-two\ndescription: Second skill.\n"
+            'metadata:\n  version: "1.0.0"\n---\n\n# Skill Two\n'
+        )
+        runner.invoke(app, ["add", str(skill2)], env=env)
+
+        # Remove both
+        result = runner.invoke(app, ["remove", "skill-one", "skill-two"], env=env)
+        assert result.exit_code == 0
+
+        # Both placements should be gone
+        assert not (home / ".claude" / "skills" / "skill-one").exists()
+        assert not (home / ".claude" / "skills" / "skill-two").exists()
+
+    def test_remove_from_source_no_matches(self, runner, isolated_env):
+        """--from-source with no matching skills should exit 0 with info."""
+        _, napoln_home, env = isolated_env
+        napoln_home.mkdir(parents=True, exist_ok=True)
+
+        import tomli_w
+
+        (napoln_home / "manifest.toml").write_text(
+            tomli_w.dumps({"napoln": {"schema": 1}, "skills": {}})
+        )
+
+        result = runner.invoke(app, ["remove", "--from-source", "nonexistent/repo"], env=env)
+        assert result.exit_code == 0
+        assert "No skills found" in result.output
+
+    def test_remove_from_source_matches(self, runner, isolated_env, tmp_path):
+        """--from-source should match against manifest's stored source URL."""
+        home, napoln_home, env = isolated_env
+
+        skill = tmp_path / "design-audit"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\nname: design-audit\ndescription: Audit skill.\n"
+            'metadata:\n  version: "1.0.0"\n---\n\n# Design Audit\n'
+        )
+        runner.invoke(app, ["add", str(skill)], env=env)
+
+        # Manually update manifest source to a GitHub URL
+        import tomllib
+
+        manifest_path = napoln_home / "manifest.toml"
+        data = tomllib.loads(manifest_path.read_text())
+        if "skills" in data and "design-audit" in data["skills"]:
+            data["skills"]["design-audit"]["source"] = "https://github.com/raiderrobert/flow"
+            manifest_path.write_text(tomli_w.dumps(data))
+
+        # Remove using shorthand that should match
+        result = runner.invoke(app, ["remove", "--from-source", "raiderrobert/flow"], env=env)
+        assert result.exit_code == 0
+        assert not (home / ".claude" / "skills" / "design-audit").exists()
+
+    def test_remove_combined_names_and_from_source(self, runner, isolated_env, tmp_path):
+        """--from-source can be combined with explicit names."""
+        home, napoln_home, env = isolated_env
+
+        skill_a = tmp_path / "skill-a"
+        skill_a.mkdir()
+        (skill_a / "SKILL.md").write_text(
+            "---\nname: skill-a\ndescription: Skill A.\n"
+            'metadata:\n  version: "1.0.0"\n---\n\n# Skill A\n'
+        )
+        runner.invoke(app, ["add", str(skill_a)], env=env)
+
+        skill_b = tmp_path / "skill-b"
+        skill_b.mkdir()
+        (skill_b / "SKILL.md").write_text(
+            "---\nname: skill-b\ndescription: Skill B.\n"
+            'metadata:\n  version: "1.0.0"\n---\n\n# Skill B\n'
+        )
+        runner.invoke(app, ["add", str(skill_b)], env=env)
+
+        # Remove skill-a explicitly and skill-b via from-source
+        result = runner.invoke(
+            app, ["remove", "skill-a", "--from-source", "raiderrobert/other"], env=env
+        )
+        # skill-a should be removed, skill-b stays (no match)
+        assert not (home / ".claude" / "skills" / "skill-a").exists()
+        assert (home / ".claude" / "skills" / "skill-b").exists()
 
 
 class TestListCommand:

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -87,6 +87,52 @@ class TestParseSource:
         assert parsed.repo == "repo"
 
 
+class TestNormalizeSourceForMatch:
+    """Source normalization for --from-source matching."""
+
+    def test_full_github_url(self):
+        """Full URLs are normalized by stripping scheme."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("https://github.com/raiderrobert/flow") == "github.com/raiderrobert/flow"
+
+    def test_github_url_with_git_suffix(self):
+        """URLs with .git suffix are normalized."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("https://github.com/raiderrobert/flow.git") == "github.com/raiderrobert/flow"
+
+    def test_git_shorthand(self):
+        """GitHub shorthand is normalized to full host/path form."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("raiderrobert/flow") == "github.com/raiderrobert/flow"
+
+    def test_already_normalized(self):
+        """Already normalized sources pass through unchanged."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("github.com/raiderrobert/flow") == "github.com/raiderrobert/flow"
+
+    def test_local_path_unchanged(self):
+        """Local paths are not normalized."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("/path/to/skill") == "/path/to/skill"
+
+    def test_http_url_stripped(self):
+        """HTTP URLs are normalized."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("http://github.com/owner/repo") == "github.com/owner/repo"
+
+    def test_git_ssh_url(self):
+        """Git SSH URLs (git@host:owner/repo) are normalized."""
+        from napoln.core.resolver import normalize_source_for_match
+
+        assert normalize_source_for_match("git@github.com:owner/repo.git") == "github.com/owner/repo"
+
+
 class TestResolveLocal:
     """Local source resolution."""
 

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -94,13 +94,19 @@ class TestNormalizeSourceForMatch:
         """Full URLs are normalized by stripping scheme."""
         from napoln.core.resolver import normalize_source_for_match
 
-        assert normalize_source_for_match("https://github.com/raiderrobert/flow") == "github.com/raiderrobert/flow"
+        assert (
+            normalize_source_for_match("https://github.com/raiderrobert/flow")
+            == "github.com/raiderrobert/flow"
+        )
 
     def test_github_url_with_git_suffix(self):
         """URLs with .git suffix are normalized."""
         from napoln.core.resolver import normalize_source_for_match
 
-        assert normalize_source_for_match("https://github.com/raiderrobert/flow.git") == "github.com/raiderrobert/flow"
+        assert (
+            normalize_source_for_match("https://github.com/raiderrobert/flow.git")
+            == "github.com/raiderrobert/flow"
+        )
 
     def test_git_shorthand(self):
         """GitHub shorthand is normalized to full host/path form."""
@@ -112,7 +118,10 @@ class TestNormalizeSourceForMatch:
         """Already normalized sources pass through unchanged."""
         from napoln.core.resolver import normalize_source_for_match
 
-        assert normalize_source_for_match("github.com/raiderrobert/flow") == "github.com/raiderrobert/flow"
+        assert (
+            normalize_source_for_match("github.com/raiderrobert/flow")
+            == "github.com/raiderrobert/flow"
+        )
 
     def test_local_path_unchanged(self):
         """Local paths are not normalized."""
@@ -130,7 +139,9 @@ class TestNormalizeSourceForMatch:
         """Git SSH URLs (git@host:owner/repo) are normalized."""
         from napoln.core.resolver import normalize_source_for_match
 
-        assert normalize_source_for_match("git@github.com:owner/repo.git") == "github.com/owner/repo"
+        assert (
+            normalize_source_for_match("git@github.com:owner/repo.git") == "github.com/owner/repo"
+        )
 
 
 class TestResolveLocal:


### PR DESCRIPTION
## Summary

Adds two capabilities to `napoln remove`:

1. **Multiple names** — Remove multiple skills in one command
2. **`--from-source` filter** — Remove all skills from a specific repository

## Usage

```bash
# Multiple names
napoln remove design-audit design-frontend design-preflight

# All from source
napoln remove --from-source raiderrobert/flow

# Combined
napoln remove --from-source raiderrobert/flow design-audit
```

## Changes

- `src/napoln/cli.py` — `name` changed from `str` to `list[str]`, added `--from-source` option
- `src/napoln/commands/remove.py` — Loop over names, resolve `--from-source` to matching skills
- `src/napoln/core/resolver.py` — Added `normalize_source_for_match()` for URL normalization
- `tests/integration/test_cli.py` — Added 4 new test cases
- `README.md` and `napoln-manage/SKILL.md` — Updated examples

## Testing

All 176 tests pass.

Closes #30