### PR TITLE
refactor: extract get_napoln_home to core.home

### DIFF
--- a/src/napoln/commands/add.py
+++ b/src/napoln/commands/add.py
@@ -8,6 +8,7 @@ from typing import cast
 from napoln import output
 from napoln.core import agents as agents_mod
 from napoln.core import linker, manifest, store, validator
+from napoln.core.home import get_napoln_home
 from napoln.core.resolver import (
     ParsedSource,
     ResolvedSource,
@@ -19,12 +20,6 @@ from napoln.core.resolver import (
 )
 from napoln.errors import MultipleSkillsError, ResolverError
 from napoln.prompts import SkillChoice, pick_skills
-
-
-def _get_napoln_home() -> Path:
-    import os
-
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
 
 
 def _ensure_initialized(napoln_home: Path) -> None:
@@ -279,7 +274,7 @@ def run_add(
     """
     import os
 
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     home = Path(os.environ.get("HOME", Path.home()))
 
     _ensure_initialized(napoln_home)

--- a/src/napoln/commands/config.py
+++ b/src/napoln/commands/config.py
@@ -11,12 +11,7 @@ import tomli_w
 from napoln import output
 from napoln.core import agents as agents_mod
 from napoln.core import manifest, store
-
-
-def _get_napoln_home() -> Path:
-    import os
-
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
+from napoln.core.home import get_napoln_home
 
 
 # ─── config (bare) ───────────────────────────────────────────────────────────
@@ -26,7 +21,7 @@ def run_config_show() -> int:
     """Show current configuration: home, store, agents, manifests."""
     import os
 
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     home = Path(os.environ.get("HOME", Path.home()))
 
     output.header("napoln config")
@@ -77,7 +72,7 @@ def run_config_set(key: str, value: str) -> int:
 
     Keys use dot notation: e.g., "napoln.default_scope"
     """
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     config_path = napoln_home / "config.toml"
 
     if config_path.exists():
@@ -128,7 +123,7 @@ def run_config_doctor(
     json_output: bool = False,
 ) -> int:
     """Health check: store integrity, placements, provenance, git."""
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     manifest_path = manifest.get_manifest_path(napoln_home, scope, project_root)
 
     issues: list[dict] = []
@@ -253,7 +248,7 @@ def run_config_doctor(
 
 def run_config_gc(dry_run: bool = False) -> int:
     """Remove unreferenced store entries."""
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
 
     # Collect all referenced store entries from both manifests
     referenced: set[str] = set()

--- a/src/napoln/commands/install.py
+++ b/src/napoln/commands/install.py
@@ -6,13 +6,8 @@ from pathlib import Path
 
 from napoln import output
 from napoln.core import linker, manifest, store
+from napoln.core.home import get_napoln_home
 from napoln.errors import NapolnError
-
-
-def _get_napoln_home() -> Path:
-    import os
-
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
 
 
 def _sync_manifest(
@@ -27,7 +22,7 @@ def _sync_manifest(
     """
     synced = 0
     errors = 0
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
 
     for skill_name, entry in sorted(mf.skills.items()):
         try:
@@ -75,7 +70,7 @@ def run_install(
     Returns:
         Exit code (0=success, 1=errors).
     """
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
 
     if dry_run:
         output.dry_run_header()

--- a/src/napoln/commands/list_cmd.py
+++ b/src/napoln/commands/list_cmd.py
@@ -6,12 +6,7 @@ from pathlib import Path
 
 from napoln import output
 from napoln.core import manifest
-
-
-def _get_napoln_home() -> Path:
-    import os
-
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
+from napoln.core.home import get_napoln_home
 
 
 def _abbreviate_path(path: str, home: str) -> str:
@@ -204,7 +199,7 @@ def run_list(
     Returns:
         Exit code (0=always).
     """
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
 
     global_mf: manifest.Manifest | None = None
     project_mf: manifest.Manifest | None = None

--- a/src/napoln/commands/remove.py
+++ b/src/napoln/commands/remove.py
@@ -7,13 +7,8 @@ from pathlib import Path
 
 from napoln import output
 from napoln.core import manifest
+from napoln.core.home import get_napoln_home
 from napoln.core.resolver import normalize_source_for_match
-
-
-def _get_napoln_home() -> Path:
-    import os
-
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
 
 
 def _resolve_from_source(
@@ -61,7 +56,7 @@ def run_remove(
     Returns:
         Exit code (0=success, 1=error).
     """
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     manifest_path = manifest.get_manifest_path(napoln_home, scope, project_root)
     mf = manifest.read_manifest(manifest_path)
 

--- a/src/napoln/commands/setup.py
+++ b/src/napoln/commands/setup.py
@@ -10,11 +10,8 @@ import tomli_w
 
 from napoln import output
 from napoln.core import agents as agents_mod
+from napoln.core.home import get_napoln_home
 from napoln.prompts import pick_agents
-
-
-def _get_napoln_home() -> Path:
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
 
 
 def _ensure_initialized(napoln_home: Path) -> None:
@@ -53,7 +50,7 @@ def run_setup(force: bool = False) -> int:
     Returns:
         Exit code (0 on success, 1 on cancel/error).
     """
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     home = Path(os.environ.get("HOME", Path.home()))
     config_path = napoln_home / "config.toml"
 

--- a/src/napoln/commands/upgrade.py
+++ b/src/napoln/commands/upgrade.py
@@ -7,14 +7,9 @@ from typing import cast
 
 from napoln import output
 from napoln.core import linker, manifest, merger, store
+from napoln.core.home import get_napoln_home
 from napoln.core.resolver import ResolvedSource, parse_source, resolve_git, resolve_local
 from napoln.errors import ResolverError
-
-
-def _get_napoln_home() -> Path:
-    import os
-
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
 
 
 def run_upgrade(
@@ -33,7 +28,7 @@ def run_upgrade(
     """
     import os
 
-    napoln_home = _get_napoln_home()
+    napoln_home = get_napoln_home()
     home = Path(os.environ.get("HOME", Path.home()))
     manifest_path = manifest.get_manifest_path(napoln_home, scope, project_root)
     mf = manifest.read_manifest(manifest_path)

--- a/src/napoln/core/home.py
+++ b/src/napoln/core/home.py
@@ -1,0 +1,15 @@
+"""Resolve the napoln home directory.
+
+The home directory holds the store, cache, and global manifest.
+Defaults to ~/.napoln/, overridable with NAPOLN_HOME.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_napoln_home() -> Path:
+    """Return the configured napoln home directory."""
+    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))


### PR DESCRIPTION
## Summary
- New module `src/napoln/core/home.py` exposes `get_napoln_home()`, which resolves `NAPOLN_HOME` (or `~/.napoln/`).
- All seven command modules (`add`, `config`, `install`, `list_cmd`, `remove`, `setup`, `upgrade`) now import it instead of defining their own copy.
- Net effect: -18 lines, one source of truth for the home-directory lookup, consistent `import os` handling.

Closes #23.

## Test plan
- [x] `just check` passes (format, lint, ty, pytest — 181 tests)