### PR TITLE
fix: stage placement into temp dir before atomic swap

### DIFF
--- a/src/napoln/core/linker.py
+++ b/src/napoln/core/linker.py
@@ -6,6 +6,7 @@ Fallback: full copy via shutil.copy2 if reflink is unavailable.
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -51,8 +52,8 @@ def clone_file(src: Path, dst: Path) -> str:
 def place_skill(store_path: Path, target_dir: Path) -> str:
     """Place a skill from the store to a target directory.
 
-    All files from store_path are cloned/copied to target_dir.
-    The link mode is determined by the first file and used consistently.
+    Files are staged into a sibling temp directory, then atomically renamed
+    into place. If staging fails, the existing target_dir is left untouched.
 
     Args:
         store_path: Path to the skill in the content-addressed store.
@@ -61,38 +62,58 @@ def place_skill(store_path: Path, target_dir: Path) -> str:
     Returns:
         "clone" or "copy" depending on the link mode used.
     """
-    if target_dir.exists():
-        shutil.rmtree(target_dir)
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir = target_dir.parent / f".{target_dir.name}.tmp-placement"
+    old_dir = target_dir.parent / f".{target_dir.name}.old-{os.getpid()}"
 
-    target_dir.mkdir(parents=True, exist_ok=True)
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir)
+    if old_dir.exists():
+        shutil.rmtree(old_dir)
+
+    try:
+        temp_dir.mkdir()
+        link_mode = _populate(store_path, temp_dir)
+
+        if target_dir.exists():
+            os.rename(target_dir, old_dir)
+            try:
+                os.rename(temp_dir, target_dir)
+            except OSError:
+                # Swap failed — put the original back before re-raising.
+                os.rename(old_dir, target_dir)
+                raise
+            shutil.rmtree(old_dir)
+        else:
+            os.rename(temp_dir, target_dir)
+    except BaseException:
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
+    return link_mode
+
+
+def _populate(store_path: Path, target_dir: Path) -> str:
+    """Copy every file from store_path into target_dir, preferring reflink."""
     link_mode: str | None = None
 
     for src_file in sorted(store_path.rglob("*")):
-        if src_file.is_file():
-            rel = src_file.relative_to(store_path)
-            dst_file = target_dir / rel
-            dst_file.parent.mkdir(parents=True, exist_ok=True)
-            mode = clone_file(src_file, dst_file)
-            if link_mode is None:
-                link_mode = mode
-                # If first file failed reflink, don't try again
-                if mode == "copy":
-                    _use_copy_only(store_path, target_dir, rel)
-                    return "copy"
+        if not src_file.is_file():
+            continue
+        rel = src_file.relative_to(store_path)
+        dst_file = target_dir / rel
+        dst_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if link_mode == "copy":
+            shutil.copy2(str(src_file), str(dst_file))
+            continue
+
+        mode = clone_file(src_file, dst_file)
+        if link_mode is None:
+            link_mode = mode
 
     return link_mode or "copy"
-
-
-def _use_copy_only(store_path: Path, target_dir: Path, already_copied: Path) -> None:
-    """Copy remaining files after reflink fallback was triggered."""
-    for src_file in sorted(store_path.rglob("*")):
-        if src_file.is_file():
-            rel = src_file.relative_to(store_path)
-            if rel == already_copied:
-                continue
-            dst_file = target_dir / rel
-            dst_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(str(src_file), str(dst_file))
 
 
 def write_provenance(

--- a/tests/unit/test_linker.py
+++ b/tests/unit/test_linker.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from napoln.core import linker
 from napoln.core.linker import clone_file, place_skill
 
 
@@ -52,6 +53,35 @@ class TestPlaceSkill:
 
         place_skill(store_skill, target)
         assert (target / "SKILL.md").read_text() == "# Hello"
+
+    def test_existing_placement_survives_failed_replacement(
+        self, tmp_path, store_skill, monkeypatch
+    ):
+        """If placement fails partway, the existing target directory is preserved."""
+        target = tmp_path / "target" / "my-skill"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text("# Old content")
+        (target / "existing.txt").write_text("still here")
+
+        calls = {"n": 0}
+        real_clone_file = linker.clone_file
+
+        def flaky_clone(src, dst):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise RuntimeError("simulated interruption")
+            return real_clone_file(src, dst)
+
+        monkeypatch.setattr(linker, "clone_file", flaky_clone)
+
+        with pytest.raises(RuntimeError, match="simulated interruption"):
+            place_skill(store_skill, target)
+
+        assert (target / "SKILL.md").read_text() == "# Old content"
+        assert (target / "existing.txt").read_text() == "still here"
+        # No temp dir should be left behind.
+        leftovers = sorted(p.name for p in target.parent.iterdir() if p.name != target.name)
+        assert leftovers == [], f"unexpected siblings: {leftovers}"
 
     def test_preserves_subdirectory_structure(self, tmp_path):
         """Nested directories are preserved during placement."""


### PR DESCRIPTION
## Summary
- `place_skill` no longer `rmtree`s the target before copying files. It stages into a sibling `.<name>.tmp-placement` directory, renames any existing target aside as `.<name>.old-<pid>`, renames the temp into place, then removes the old copy.
- If staging fails, the original target is untouched. If the final rename fails, the original is put back before the error propagates.
- Split the file loop into a helper (`_populate`) so the flow inside the try/except stays easy to read.

Closes #21.

## Test plan
- [x] New `test_existing_placement_survives_failed_replacement` monkeypatches `clone_file` to succeed once then raise. It asserts that original files in the target dir (`SKILL.md` + `existing.txt`) still match their original contents and no sibling temp/old directories leak. Test fails against the old rmtree-first implementation.
- [x] `just check` — 182 tests pass.