### PR TITLE
fix: hunk-based python fallback three-way merge

### DIFF
--- a/src/napoln/core/merger.py
+++ b/src/napoln/core/merger.py
@@ -7,6 +7,7 @@ replace-if-unchanged semantics.
 
 from __future__ import annotations
 
+import difflib
 import shutil
 import subprocess
 import tempfile
@@ -101,23 +102,97 @@ def _python_merge_file(ours: Path, base: Path, theirs: Path) -> tuple[str, bool]
 
 
 def _line_merge(ours: str, base: str, theirs: str) -> tuple[str, bool]:
-    """Simple line-based three-way merge with conflict markers."""
+    """Hunk-based three-way line merge.
+
+    Disjoint changes on ours and theirs are applied together without conflicts.
+    Overlapping changes produce conflict markers scoped to the conflicting
+    region instead of the whole file.
+    """
     ours_lines = ours.splitlines(keepends=True)
+    base_lines = base.splitlines(keepends=True)
     theirs_lines = theirs.splitlines(keepends=True)
 
-    if ours == theirs:
-        # Both made the same change
-        return ours, False
+    if ours_lines == theirs_lines:
+        return "".join(ours_lines), False
 
-    # Simple fallback: produce conflict markers for the entire file
-    result = []
-    result.append("<<<<<<< local (your changes)\n")
-    result.extend(ours_lines)
-    result.append("=======\n")
-    result.extend(theirs_lines)
-    result.append(">>>>>>> upstream\n")
+    ours_hunks = _diff_hunks(base_lines, ours_lines)
+    theirs_hunks = _diff_hunks(base_lines, theirs_lines)
 
-    return "".join(result), True
+    tagged = [(i1, i2, new, "ours") for (i1, i2, new) in ours_hunks] + [
+        (i1, i2, new, "theirs") for (i1, i2, new) in theirs_hunks
+    ]
+    tagged.sort(key=lambda h: (h[0], h[1]))
+
+    groups: list[list[tuple[int, int, list[str], str]]] = []
+    for hunk in tagged:
+        if groups and hunk[0] <= max(h[1] for h in groups[-1]):
+            groups[-1].append(hunk)
+        else:
+            groups.append([hunk])
+
+    merged: list[str] = []
+    base_idx = 0
+    has_conflicts = False
+
+    for group in groups:
+        g_start = min(h[0] for h in group)
+        g_end = max(h[1] for h in group)
+        merged.extend(base_lines[base_idx:g_start])
+
+        sides = {h[3] for h in group}
+        if sides == {"ours"} or sides == {"theirs"}:
+            merged.extend(_apply_hunks(base_lines, group, g_start, g_end))
+        else:
+            ours_region = _apply_hunks(
+                base_lines, [h for h in group if h[3] == "ours"], g_start, g_end
+            )
+            theirs_region = _apply_hunks(
+                base_lines, [h for h in group if h[3] == "theirs"], g_start, g_end
+            )
+            if ours_region == theirs_region:
+                merged.extend(ours_region)
+            else:
+                merged.append("<<<<<<< local (your changes)\n")
+                merged.extend(ours_region)
+                merged.append("=======\n")
+                merged.extend(theirs_region)
+                merged.append(">>>>>>> upstream\n")
+                has_conflicts = True
+
+        base_idx = g_end
+
+    merged.extend(base_lines[base_idx:])
+    return "".join(merged), has_conflicts
+
+
+def _diff_hunks(base: list[str], other: list[str]) -> list[tuple[int, int, list[str]]]:
+    """Return the non-equal opcodes as (base_start, base_end, replacement_lines)."""
+    matcher = difflib.SequenceMatcher(a=base, b=other, autojunk=False)
+    hunks: list[tuple[int, int, list[str]]] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        hunks.append((i1, i2, other[j1:j2]))
+    return hunks
+
+
+def _apply_hunks(
+    base: list[str],
+    hunks: list[tuple[int, int, list[str], str]],
+    start: int,
+    end: int,
+) -> list[str]:
+    """Apply a set of non-overlapping hunks to base[start:end]."""
+    result: list[str] = []
+    idx = start
+    for i1, i2, new_lines, _side in sorted(hunks, key=lambda h: h[0]):
+        if i1 > idx:
+            result.extend(base[idx:i1])
+        result.extend(new_lines)
+        idx = i2
+    if idx < end:
+        result.extend(base[idx:end])
+    return result
 
 
 def merge_skill(

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -2,7 +2,15 @@
 
 import pytest
 
+from napoln.core import merger
 from napoln.core.merger import has_conflict_markers, merge_file, merge_skill
+
+
+def _write_triplet(tmp_path, ours, base, theirs):
+    (tmp_path / "ours").write_text(ours)
+    (tmp_path / "base").write_text(base)
+    (tmp_path / "theirs").write_text(theirs)
+    return tmp_path / "ours", tmp_path / "base", tmp_path / "theirs"
 
 
 class TestMergeFile:
@@ -65,6 +73,71 @@ class TestMergeFile:
         )
         assert has_conflicts
         assert "<<<<<<<" in merged
+
+
+class TestPythonFallbackMerge:
+    """Python fallback merge (used when git is unavailable)."""
+
+    @pytest.fixture(autouse=True)
+    def _force_fallback(self, monkeypatch):
+        monkeypatch.setattr(merger, "has_git", lambda: False)
+
+    def test_disjoint_additions_merge_cleanly(self, tmp_path):
+        """Adding lines at opposite ends of the file must not conflict."""
+        base = "# Skill\n\n## Instructions\n1. Step one\n2. Step two\n"
+        ours = "# Skill\n\n## Instructions\n1. Step one\n2. Step two\n\n## Tips\nAsk for help if stuck.\n"
+        theirs = (
+            "# Skill\n\n## Prerequisites\nRequires Python 3.11+\n\n"
+            "## Instructions\n1. Step one\n2. Step two\n"
+        )
+
+        ours_p, base_p, theirs_p = _write_triplet(tmp_path, ours, base, theirs)
+        merged, has_conflicts = merge_file(ours_p, base_p, theirs_p)
+
+        assert not has_conflicts
+        assert "<<<<<<<" not in merged
+        assert "## Tips" in merged
+        assert "## Prerequisites" in merged
+        assert "Requires Python 3.11+" in merged
+        assert "Ask for help if stuck." in merged
+
+    def test_overlapping_edits_emit_conflict_markers(self, tmp_path):
+        """When both sides edit the same region the result has conflict markers."""
+        base = "line 1\nline 2\nline 3\n"
+        ours = "line 1\nlocal change\nline 3\n"
+        theirs = "line 1\nupstream change\nline 3\n"
+
+        ours_p, base_p, theirs_p = _write_triplet(tmp_path, ours, base, theirs)
+        merged, has_conflicts = merge_file(ours_p, base_p, theirs_p)
+
+        assert has_conflicts
+        assert "<<<<<<<" in merged
+        assert "=======" in merged
+        assert ">>>>>>>" in merged
+        assert "local change" in merged
+        assert "upstream change" in merged
+        # Unchanged context around the conflict is preserved outside the markers.
+        assert merged.startswith("line 1\n")
+        assert merged.rstrip().endswith("line 3")
+
+    def test_identical_changes_merge_cleanly(self, tmp_path):
+        """If both sides make the same change, no conflict."""
+        ours_p, base_p, theirs_p = _write_triplet(tmp_path, "v2\n", "v1\n", "v2\n")
+        merged, has_conflicts = merge_file(ours_p, base_p, theirs_p)
+        assert not has_conflicts
+        assert merged == "v2\n"
+
+    def test_only_local_changes(self, tmp_path):
+        ours_p, base_p, theirs_p = _write_triplet(tmp_path, "local\n", "base\n", "base\n")
+        merged, has_conflicts = merge_file(ours_p, base_p, theirs_p)
+        assert not has_conflicts
+        assert merged == "local\n"
+
+    def test_only_upstream_changes(self, tmp_path):
+        ours_p, base_p, theirs_p = _write_triplet(tmp_path, "base\n", "base\n", "upstream\n")
+        merged, has_conflicts = merge_file(ours_p, base_p, theirs_p)
+        assert not has_conflicts
+        assert merged == "upstream\n"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- When `git merge-file` is unavailable, `_line_merge` used to wrap the **whole file** in conflict markers as soon as both sides changed anything.
- Replaced with a hunk-based merge: compute opcodes for base→ours and base→theirs, group overlapping hunks, then apply disjoint changes cleanly and emit conflict markers only for regions where both sides touch the same lines.

Closes #22.

## Test plan
- [x] New `TestPythonFallbackMerge` class forces `has_git` to `False` and exercises: disjoint additions (header + footer) merge cleanly, overlapping line edits emit conflict markers, identical changes merge cleanly, ours-only fast-forwards, theirs-only fast-forwards.
- [x] `just check` — 186 tests pass.