### PR TITLE
perf: scope and throttle git fetches in resolve_git

### DIFF
--- a/src/napoln/core/resolver.py
+++ b/src/napoln/core/resolver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -34,6 +35,26 @@ _DOMAIN_PATH = re.compile(
     r"^([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/([a-zA-Z0-9._-]+)/([a-zA-Z0-9._-]+)(?:/(.+?))?(?:@(.+))?$"
 )
 _SEMVER_TAG = re.compile(r"^v?(\d+\.\d+\.\d+(?:-.+)?)$")
+
+# Cached git fetches are considered fresh within this many seconds.
+_FETCH_THROTTLE_SECONDS = 300
+
+
+def _fetch_sentinel(cache_dir: Path, owner: str, repo: str) -> Path:
+    """Return the path to the last-fetch marker for a cached clone."""
+    return cache_dir / f".{owner}-{repo}.last-fetch"
+
+
+def _should_fetch(sentinel: Path, now: float | None = None) -> bool:
+    """Return True if the cached clone's fetch marker is missing or stale."""
+    if not sentinel.exists():
+        return True
+    try:
+        mtime = sentinel.stat().st_mtime
+    except OSError:
+        return True
+    current = time.time() if now is None else now
+    return (current - mtime) >= _FETCH_THROTTLE_SECONDS
 
 
 @dataclass
@@ -222,16 +243,20 @@ def resolve_git(
 
     repo_url = f"https://{parsed.host}/{parsed.owner}/{parsed.repo}.git"
     clone_dir = cache_dir / f"{parsed.owner}-{parsed.repo}"
+    sentinel = _fetch_sentinel(cache_dir, parsed.owner, parsed.repo)
 
     try:
         if clone_dir.exists():
-            # Update existing clone
-            subprocess.run(
-                ["git", "fetch", "--all", "--tags"],
-                cwd=str(clone_dir),
-                capture_output=True,
-                check=True,
-            )
+            # Refresh the existing clone, but throttle to avoid a fetch per
+            # add/upgrade on large repos.
+            if _should_fetch(sentinel):
+                subprocess.run(
+                    ["git", "fetch", "origin", "--tags"],
+                    cwd=str(clone_dir),
+                    capture_output=True,
+                    check=True,
+                )
+                sentinel.touch()
         else:
             # Fresh clone
             clone_dir.mkdir(parents=True, exist_ok=True)
@@ -240,6 +265,7 @@ def resolve_git(
                 capture_output=True,
                 check=True,
             )
+            sentinel.touch()
     except subprocess.CalledProcessError as e:
         raise ResolverError(
             f"Failed to clone {repo_url}",

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,8 +1,17 @@
 """Tests for napoln.core.resolver — source parsing and resolution."""
 
+import subprocess
+
 import pytest
 
-from napoln.core.resolver import ParsedSource, parse_source, resolve_local
+from napoln.core import resolver
+from napoln.core.resolver import (
+    ParsedSource,
+    _fetch_sentinel,
+    _should_fetch,
+    parse_source,
+    resolve_local,
+)
 from napoln.errors import ResolverError
 
 
@@ -186,3 +195,100 @@ class TestResolveLocal:
 
         resolved = resolve_local(_local_parsed(skill_dir))
         assert resolved.version == "0.0.0"
+
+
+class TestShouldFetch:
+    """Throttle decision for cached git fetches."""
+
+    def test_missing_sentinel_triggers_fetch(self, tmp_path):
+        assert _should_fetch(tmp_path / ".missing") is True
+
+    def test_recent_sentinel_skips_fetch(self, tmp_path):
+        sentinel = tmp_path / ".last-fetch"
+        sentinel.touch()
+        assert _should_fetch(sentinel, now=sentinel.stat().st_mtime + 10) is False
+
+    def test_stale_sentinel_triggers_fetch(self, tmp_path):
+        sentinel = tmp_path / ".last-fetch"
+        sentinel.touch()
+        assert _should_fetch(sentinel, now=sentinel.stat().st_mtime + 3600) is True
+
+
+class TestResolveGitFetch:
+    """resolve_git fetch scope and throttling."""
+
+    @pytest.fixture
+    def git_parsed(self):
+        return ParsedSource(
+            source_type="git",
+            host="github.com",
+            owner="owner",
+            repo="repo",
+            path="",
+            version="main",
+            original="owner/repo@main",
+        )
+
+    @pytest.fixture
+    def populated_cache(self, tmp_path, git_parsed):
+        """A cache dir with an already-cloned repo containing a SKILL.md."""
+        cache_dir = tmp_path / "cache"
+        clone_dir = cache_dir / f"{git_parsed.owner}-{git_parsed.repo}"
+        clone_dir.mkdir(parents=True)
+        (clone_dir / "SKILL.md").write_text("---\nname: repo\ndescription: x\n---\n# Hi")
+        return cache_dir, clone_dir
+
+    def _install_fake_git(self, monkeypatch, calls):
+        monkeypatch.setattr(resolver.shutil, "which", lambda _: "/usr/bin/git")
+
+        def fake_run(cmd, *_args, **_kwargs):
+            calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(resolver.subprocess, "run", fake_run)
+
+    def test_fetch_uses_origin_not_all_and_writes_sentinel(
+        self, monkeypatch, git_parsed, populated_cache
+    ):
+        cache_dir, _ = populated_cache
+        calls: list[list[str]] = []
+        self._install_fake_git(monkeypatch, calls)
+
+        resolver.resolve_git(git_parsed, cache_dir)
+
+        fetch_calls = [c for c in calls if c[:2] == ["git", "fetch"]]
+        assert fetch_calls == [["git", "fetch", "origin", "--tags"]]
+        assert _fetch_sentinel(cache_dir, git_parsed.owner, git_parsed.repo).exists()
+
+    def test_second_resolve_within_throttle_skips_fetch(
+        self, monkeypatch, git_parsed, populated_cache
+    ):
+        cache_dir, _ = populated_cache
+        calls: list[list[str]] = []
+        self._install_fake_git(monkeypatch, calls)
+
+        resolver.resolve_git(git_parsed, cache_dir)
+        fetch_count_after_first = sum(1 for c in calls if c[:2] == ["git", "fetch"])
+        resolver.resolve_git(git_parsed, cache_dir)
+        fetch_count_after_second = sum(1 for c in calls if c[:2] == ["git", "fetch"])
+
+        assert fetch_count_after_first == 1
+        assert fetch_count_after_second == 1  # second call reused the cache
+
+    def test_stale_sentinel_re_fetches(self, monkeypatch, git_parsed, populated_cache):
+        cache_dir, _ = populated_cache
+        calls: list[list[str]] = []
+        self._install_fake_git(monkeypatch, calls)
+
+        resolver.resolve_git(git_parsed, cache_dir)
+
+        sentinel = _fetch_sentinel(cache_dir, git_parsed.owner, git_parsed.repo)
+        import os as _os
+
+        old = sentinel.stat().st_mtime - (resolver._FETCH_THROTTLE_SECONDS + 60)
+        _os.utime(sentinel, (old, old))
+
+        resolver.resolve_git(git_parsed, cache_dir)
+
+        fetch_calls = [c for c in calls if c[:2] == ["git", "fetch"]]
+        assert len(fetch_calls) == 2


### PR DESCRIPTION
## Summary
- `resolve_git` previously ran `git fetch --all --tags` on every invocation, even for back-to-back `napoln add`/`upgrade` calls. Two changes:
  - Fetch is now scoped to `origin --tags`. Large repos with extra remotes no longer drag in unrelated history.
  - A sidecar sentinel (`<cache>/.<owner>-<repo>.last-fetch`) records when the clone was last refreshed. Fetches within `_FETCH_THROTTLE_SECONDS` (5 min) are skipped.

The issue also mentioned silent `subprocess.CalledProcessError` swallowing; that's already handled — the existing `check=True` path raises `ResolverError` with stderr attached. Kept that path intact.

Closes #25.

## Test plan
- [x] `TestShouldFetch` covers missing, fresh, and stale sentinel states.
- [x] `TestResolveGitFetch` stubs `subprocess.run` and `shutil.which` to assert:
  - fetch uses `origin --tags` (not `--all --tags`) and writes the sentinel,
  - a second resolve within the window reuses the cache with no extra fetch,
  - backdating the sentinel past the throttle triggers a second fetch.
- [x] `just check` — 187 tests pass.