### PR TITLE
feat(init): append skill placement dirs to .gitignore

### DIFF
--- a/src/napoln/commands/init.py
+++ b/src/napoln/commands/init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from napoln import output
+from napoln.core import agents as agents_mod
 
 
 SKILL_TEMPLATE = """\
@@ -22,6 +23,8 @@ Describe what this skill does and when to use it.
 1. Step one
 2. Step two
 """
+
+_GITIGNORE_HEADER = "# napoln skill placements"
 
 
 def run_init(name: str | None = None) -> int:
@@ -46,9 +49,69 @@ def run_init(name: str | None = None) -> int:
         output.error(f"SKILL.md already exists at {skill_md}")
         return 1
 
-    # Title-case the name for the heading
     title = name.replace("-", " ").replace("_", " ").title()
 
     skill_md.write_text(SKILL_TEMPLATE.format(name=name, title=title))
     output.success(f"Created {skill_md}")
+
+    _update_gitignore(Path.cwd())
+
     return 0
+
+
+def _find_git_root(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for a directory containing ``.git``."""
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _placement_gitignore_entries() -> list[str]:
+    """Return unique placement directories (with trailing slash) for every agent.
+
+    Covers both project-scope and global-scope directories so users who
+    accidentally create either inside a repo do not commit placements.
+    """
+    seen: list[str] = []
+    for agent in agents_mod.AGENTS.values():
+        for raw in (agent.project_skill_dir, agent.global_skill_dir):
+            entry = f"{raw.rstrip('/')}/"
+            if entry not in seen:
+                seen.append(entry)
+    return seen
+
+
+def _update_gitignore(cwd: Path) -> None:
+    """Append missing placement-directory entries to the repo's .gitignore."""
+    git_root = _find_git_root(cwd)
+    if git_root is None:
+        return
+
+    gitignore = git_root / ".gitignore"
+    entries = _placement_gitignore_entries()
+
+    if gitignore.exists():
+        existing_text = gitignore.read_text(encoding="utf-8")
+        existing_lines = {line.strip() for line in existing_text.splitlines()}
+    else:
+        existing_text = ""
+        existing_lines = set()
+
+    missing = [e for e in entries if e not in existing_lines]
+    if not missing:
+        output.info(f"{gitignore} already lists skill placement directories.")
+        return
+
+    prefix = ""
+    if existing_text and not existing_text.endswith("\n"):
+        prefix = "\n"
+    block = prefix + f"\n{_GITIGNORE_HEADER}\n" + "\n".join(missing) + "\n"
+
+    with gitignore.open("a", encoding="utf-8") as fh:
+        fh.write(block)
+
+    output.success(
+        f"Updated {gitignore} with {len(missing)} skill placement "
+        f"{'entry' if len(missing) == 1 else 'entries'}: {', '.join(missing)}"
+    )

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -416,6 +416,71 @@ class TestInitCommand:
         assert result.exit_code == 0
         assert "Scaffold" in result.output
 
+    def test_init_creates_gitignore_inside_git_repo(self, runner, tmp_path):
+        import os
+
+        (tmp_path / ".git").mkdir()
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(app, ["init", "my-skill"])
+            assert result.exit_code == 0
+            gitignore = (tmp_path / ".gitignore").read_text()
+            assert ".claude/skills/" in gitignore
+            assert ".agents/skills/" in gitignore
+            assert ".cursor/skills/" in gitignore
+            assert "gitignore" in result.output.lower()
+        finally:
+            os.chdir(old_cwd)
+
+    def test_init_gitignore_is_idempotent(self, runner, tmp_path):
+        import os
+
+        (tmp_path / ".git").mkdir()
+        existing = "# existing rules\n.claude/skills/\n.agents/skills/\n.cursor/skills/\n"
+        (tmp_path / ".gitignore").write_text(existing)
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(app, ["init", "my-skill"])
+            assert result.exit_code == 0
+            # No duplicates, no spurious changes.
+            assert (tmp_path / ".gitignore").read_text() == existing
+            assert "already" in result.output.lower() or "no changes" in result.output.lower()
+        finally:
+            os.chdir(old_cwd)
+
+    def test_init_gitignore_appends_only_missing_entries(self, runner, tmp_path):
+        import os
+
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".gitignore").write_text("# existing\n.claude/skills/\n")
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(app, ["init", "my-skill"])
+            assert result.exit_code == 0
+            content = (tmp_path / ".gitignore").read_text()
+            assert content.count(".claude/skills/") == 1
+            assert ".agents/skills/" in content
+            assert ".cursor/skills/" in content
+        finally:
+            os.chdir(old_cwd)
+
+    def test_init_skips_gitignore_outside_git_repo(self, runner, tmp_path):
+        import os
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(app, ["init", "my-skill"])
+            assert result.exit_code == 0
+            assert not (tmp_path / ".gitignore").exists()
+        finally:
+            os.chdir(old_cwd)
+
 
 class TestConfigCommand:
     def test_config_show(self, runner, isolated_env, local_skill):


### PR DESCRIPTION
## Summary
- When `napoln init` runs inside a git repository, it now appends skill placement directories to the repo root's `.gitignore` under a `# napoln skill placements` header.
- Entries are derived from `napoln.core.agents.AGENTS` (both project- and global-scope dirs), so `.claude/skills/`, `.agents/skills/`, and `.cursor/skills/` are covered today and future agents are picked up automatically.
- Idempotent: existing matching lines are left alone; only missing entries are appended. Outside a git repo, `.gitignore` is not touched.

Closes #7.

## Test plan
- [x] New tests in `TestInitCommand`:
  - creates `.gitignore` with all placement entries inside a git repo,
  - is a no-op (and informs the user) when entries already exist,
  - appends only the missing entries when some already exist,
  - does nothing to `.gitignore` outside a git repo.
- [x] `just check` — 185 tests pass.