### PR TITLE
feat: add napoln enable command

### DIFF
--- a/src/napoln/cli.py
+++ b/src/napoln/cli.py
@@ -225,6 +225,34 @@ def install(
     raise typer.Exit(code=exit_code)
 
 
+# ─── enable ──────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def enable(
+    agent: Annotated[
+        Optional[str],
+        typer.Argument(help="Agent to enable skills for (e.g., hermes, claude-code)."),
+    ] = None,
+    project: Annotated[
+        bool, typer.Option("--project", "-p", help="Enable skills in project scope.")
+    ] = False,
+) -> None:
+    """Extend installed skills to additional agents."""
+    from napoln.commands.enable import run_enable
+
+    agent_ids = [agent] if agent else None
+    scope = "project" if project else "global"
+    project_root = Path.cwd() if project else None
+
+    exit_code = run_enable(
+        agent_ids=agent_ids,
+        scope=scope,
+        project_root=project_root,
+    )
+    raise typer.Exit(code=exit_code)
+
+
 # ─── init ─────────────────────────────────────────────────────────────────────
 
 

--- a/src/napoln/commands/enable.py
+++ b/src/napoln/commands/enable.py
@@ -1,0 +1,200 @@
+"""napoln enable — Extend installed skills to additional agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from napoln import output
+from napoln.core import agents as agents_mod
+from napoln.core import linker, manifest, store
+from napoln.core.home import get_napoln_home
+from napoln.prompts import SkillChoice, pick_agents, pick_skills
+
+
+def _get_skills_to_enable(
+    mf: manifest.Manifest,
+    agent_id: str,
+) -> list[tuple[str, manifest.SkillEntry]]:
+    """Return skills not yet placed for the given agent.
+
+    Args:
+        mf: The manifest to check.
+        agent_id: The agent ID to filter by.
+
+    Returns:
+        List of (skill_name, SkillEntry) tuples for skills not placed for this agent.
+    """
+    skills = []
+    for name, entry in mf.skills.items():
+        if agent_id not in entry.agents:
+            skills.append((name, entry))
+    return skills
+
+
+def _place_skill_for_agent(
+    skill_name: str,
+    skill_entry: manifest.SkillEntry,
+    agent_config: agents_mod.AgentConfig,
+    napoln_home: Path,
+    home: Path,
+    scope: str,
+    project_root: Path | None,
+) -> str | None:
+    """Place a single skill for an agent.
+
+    Args:
+        skill_name: Name of the skill.
+        skill_entry: Skill entry from manifest.
+        agent_config: Agent configuration.
+        napoln_home: napoln home path.
+        home: User home path.
+        scope: "global" or "project".
+        project_root: Project root for project scope.
+
+    Returns:
+        Link mode on success, None on failure.
+    """
+    # Get store path - will re-fetch if needed
+    try:
+        store_path = store.ensure_stored(
+            skill_name,
+            skill_entry.version,
+            skill_entry.store_hash,
+            skill_entry.source,
+            napoln_home,
+        )
+    except Exception as e:
+        output.error(f"Failed to retrieve '{skill_name}' from store: {e}")
+        return None
+
+    # Get target path
+    target_path = agent_config.skill_path(home, skill_name, scope, project_root)
+
+    # Place
+    try:
+        link_mode = linker.place_skill(store_path, target_path)
+        linker.write_provenance(
+            target_path,
+            skill_entry.source,
+            skill_entry.version,
+            skill_entry.store_hash,
+            link_mode,
+        )
+        return link_mode
+    except Exception as e:
+        output.error(f"Failed to place '{skill_name}': {e}")
+        return None
+
+
+def run_enable(
+    agent_ids: list[str] | None,
+    scope: str = "global",
+    project_root: Path | None = None,
+) -> int:
+    """Execute the enable command.
+
+    Args:
+        agent_ids: Specific agent IDs to enable, or None to pick interactively.
+        scope: "global" or "project".
+        project_root: Project root for project scope.
+
+    Returns:
+        Exit code (0=success, 1=error).
+    """
+    import os
+
+    napoln_home = get_napoln_home()
+    home = Path(os.environ.get("HOME", Path.home()))
+
+    # Determine which agents to enable
+    if agent_ids:
+        # Validate agent IDs
+        for aid in agent_ids:
+            if aid not in agents_mod.AGENTS:
+                output.error(
+                    f"Unknown agent: {aid}. Available: {', '.join(agents_mod.AGENTS.keys())}"
+                )
+                return 1
+        target_agents = [agents_mod.AGENTS[aid] for aid in agent_ids]
+    else:
+        # Interactive agent picker
+        available = agents_mod.detect_agents(home, project_root, scope)
+        if not available:
+            output.error("No agents detected. Install an agent first.")
+            return 1
+
+        selected = pick_agents(available)
+        if selected is None:
+            return 1  # User cancelled
+        if not selected:
+            output.info("No agents selected.")
+            return 0
+        target_agents = cast(list[agents_mod.AgentConfig], selected)
+
+    # Load manifest
+    manifest_path = manifest.get_manifest_path(napoln_home, scope, project_root)
+    mf = manifest.read_manifest(manifest_path)
+
+    if not mf.skills:
+        output.info("No skills installed.")
+        return 0
+
+    # Process each agent
+    for agent in target_agents:
+        skills_to_enable = _get_skills_to_enable(mf, agent.id)
+
+        if not skills_to_enable:
+            output.success(f"All skills already enabled for {agent.display_name}")
+            continue
+
+        skill_count = len(skills_to_enable)
+        output.info(
+            f"Found {skill_count} skill(s). Select skills to enable for {agent.display_name}:"
+        )
+
+        # Build picker choices
+        choices = [
+            SkillChoice(
+                name=name,
+                description=f"{entry.source} (v{entry.version})",
+                path=Path(entry.source),
+            )
+            for name, entry in skills_to_enable
+        ]
+
+        selected = pick_skills(choices)
+        if not selected:
+            output.info(f"No skills selected for {agent.display_name}")
+            continue
+
+        # Place selected skills
+        enabled_count = 0
+        for choice in selected:
+            skill_entry = mf.skills[choice.name]
+            link_mode = _place_skill_for_agent(
+                choice.name,
+                skill_entry,
+                agent,
+                napoln_home,
+                home,
+                scope,
+                project_root,
+            )
+            if link_mode:
+                output.success(f"Enabled '{choice.name}' for {agent.display_name}")
+                # Update manifest
+                skill_entry.agents[agent.id] = manifest.AgentPlacement(
+                    path=str(agent.skill_path(home, choice.name, scope, project_root)),
+                    link_mode=link_mode,
+                    scope=scope,
+                )
+                enabled_count += 1
+
+        # Write manifest after processing this agent
+        manifest.write_manifest(mf, manifest_path)
+
+        if enabled_count > 0:
+            output.success(f"Enabled {enabled_count} skill(s) for {agent.display_name}")
+
+    return 0

--- a/tests/unit/test_enable.py
+++ b/tests/unit/test_enable.py
@@ -1,0 +1,117 @@
+"""Tests for napoln.commands.enable."""
+
+from __future__ import annotations
+
+from napoln.commands.enable import _get_skills_to_enable
+from napoln.core import manifest as manifest_mod
+
+
+class TestGetSkillsToEnable:
+    """Filter skills not yet placed for an agent."""
+
+    def test_no_skills(self):
+        """Empty manifest returns empty list."""
+        mf = manifest_mod.Manifest()
+        result = _get_skills_to_enable(mf, "hermes")
+        assert result == []
+
+    def test_all_enabled(self):
+        """Skill already placed for agent is filtered out."""
+        mf = manifest_mod.Manifest()
+        mf.skills["test-skill"] = manifest_mod.SkillEntry(
+            source="owner/repo",
+            version="1.0.0",
+            store_hash="abc123",
+            installed="2024-01-01T00:00:00Z",
+            updated="2024-01-01T00:00:00Z",
+            agents={
+                "hermes": manifest_mod.AgentPlacement(
+                    path="/home/.hermes/skills/test-skill",
+                    link_mode="clone",
+                    scope="global",
+                )
+            },
+        )
+        result = _get_skills_to_enable(mf, "hermes")
+        assert result == []
+
+    def test_some_enabled(self):
+        """Skills not placed for agent are returned."""
+        mf = manifest_mod.Manifest()
+        mf.skills["skill-a"] = manifest_mod.SkillEntry(
+            source="owner/repo",
+            version="1.0.0",
+            store_hash="abc123",
+            installed="2024-01-01T00:00:00Z",
+            updated="2024-01-01T00:00:00Z",
+            agents={
+                "claude-code": manifest_mod.AgentPlacement(
+                    path="/home/.claude/skills/skill-a",
+                    link_mode="clone",
+                    scope="global",
+                )
+            },
+        )
+        mf.skills["skill-b"] = manifest_mod.SkillEntry(
+            source="other/repo",
+            version="2.0.0",
+            store_hash="def456",
+            installed="2024-01-01T00:00:00Z",
+            updated="2024-01-01T00:00:00Z",
+            agents={},  # Not placed for anyone
+        )
+        result = _get_skills_to_enable(mf, "hermes")
+        assert len(result) == 2
+        names = {name for name, _ in result}
+        assert "skill-a" in names
+        assert "skill-b" in names
+
+    def test_mixed_placement(self):
+        """Some skills placed, some not, for the same agent."""
+        mf = manifest_mod.Manifest()
+        mf.skills["placed"] = manifest_mod.SkillEntry(
+            source="owner/placed",
+            version="1.0.0",
+            store_hash="abc123",
+            installed="2024-01-01T00:00:00Z",
+            updated="2024-01-01T00:00:00Z",
+            agents={
+                "hermes": manifest_mod.AgentPlacement(
+                    path="/home/.hermes/skills/placed",
+                    link_mode="clone",
+                    scope="global",
+                )
+            },
+        )
+        mf.skills["not-placed"] = manifest_mod.SkillEntry(
+            source="owner/not-placed",
+            version="1.0.0",
+            store_hash="def456",
+            installed="2024-01-01T00:00:00Z",
+            updated="2024-01-01T00:00:00Z",
+            agents={},
+        )
+        result = _get_skills_to_enable(mf, "hermes")
+        assert len(result) == 1
+        assert result[0][0] == "not-placed"
+
+    def test_skill_placed_for_different_agent(self):
+        """Skill placed for another agent is included."""
+        mf = manifest_mod.Manifest()
+        mf.skills["skill-a"] = manifest_mod.SkillEntry(
+            source="owner/repo",
+            version="1.0.0",
+            store_hash="abc123",
+            installed="2024-01-01T00:00:00Z",
+            updated="2024-01-01T00:00:00Z",
+            agents={
+                "claude-code": manifest_mod.AgentPlacement(
+                    path="/home/.claude/skills/skill-a",
+                    link_mode="clone",
+                    scope="global",
+                )
+            },
+        )
+        result = _get_skills_to_enable(mf, "hermes")
+        assert len(result) == 1
+        assert result[0][0] == "skill-a"


### PR DESCRIPTION
Add enable command to extend installed skills to additional agents without re-downloading.

## Summary

When adding a new agent support (e.g., Hermes), users need a way to enable existing skills for the new agent without re-installing. This command provides better ergonomics than `napoln add` for this use case.

## Features

- `napoln enable` — Interactive picker for agent(s) then skill(s)
- `napoln enable <agent>` — Enable skills for specific agent
- `--project` flag for project-scoped operations
- Skips skills already placed for target agent

## Example

```bash
# Interactive - pick agents, then pick skills
napoln enable

# Enable all eligible skills for a specific agent
napoln enable hermes

# Project scope
napoln enable hermes --project
```