### PR TITLE
refactor: define NAPOLN_DIR constant for repeated .napoln string

### DIFF
--- a/src/napoln/commands/config.py
+++ b/src/napoln/commands/config.py
@@ -11,7 +11,7 @@ import tomli_w
 from napoln import output
 from napoln.core import agents as agents_mod
 from napoln.core import manifest, store
-from napoln.core.home import get_napoln_home
+from napoln.core.home import NAPOLN_DIR, get_napoln_home
 
 
 # ─── config (bare) ───────────────────────────────────────────────────────────
@@ -54,7 +54,7 @@ def run_config_show() -> int:
         output.info(f"Global:    {global_path} (not created)")
 
     # Project manifest
-    project_path = Path.cwd() / ".napoln" / "manifest.toml"
+    project_path = Path.cwd() / NAPOLN_DIR / "manifest.toml"
     if project_path.exists():
         pmf = manifest.read_manifest(project_path)
         output.info(f"Project:   {project_path} ({len(pmf.skills)} skills)")
@@ -261,7 +261,7 @@ def run_config_gc(dry_run: bool = False) -> int:
         referenced.add(f"{name}/{entry.version}-{entry.store_hash}")
 
     # Also check project manifest if present
-    project_path = Path.cwd() / ".napoln" / "manifest.toml"
+    project_path = Path.cwd() / NAPOLN_DIR / "manifest.toml"
     if project_path.exists():
         project_mf = manifest.read_manifest(project_path)
         for name, entry in project_mf.skills.items():

--- a/src/napoln/commands/install.py
+++ b/src/napoln/commands/install.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from napoln import output
 from napoln.core import linker, manifest, store
-from napoln.core.home import get_napoln_home
+from napoln.core.home import NAPOLN_DIR, get_napoln_home
 from napoln.errors import NapolnError
 
 
@@ -98,7 +98,7 @@ def run_install(
 
     # Project manifest
     if not global_only:
-        project_path = Path.cwd() / ".napoln" / "manifest.toml"
+        project_path = Path.cwd() / NAPOLN_DIR / "manifest.toml"
         if project_path.exists():
             project_mf = manifest.read_manifest(project_path)
             if project_mf.skills:

--- a/src/napoln/commands/list_cmd.py
+++ b/src/napoln/commands/list_cmd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from napoln import output
 from napoln.core import manifest
-from napoln.core.home import get_napoln_home
+from napoln.core.home import NAPOLN_DIR, get_napoln_home
 
 
 def _abbreviate_path(path: str, home: str) -> str:
@@ -211,7 +211,7 @@ def run_list(
 
     # Read project manifest if it exists
     if not global_only:
-        project_path = Path.cwd() / ".napoln" / "manifest.toml"
+        project_path = Path.cwd() / NAPOLN_DIR / "manifest.toml"
         if project_path.exists() and project_path.resolve() != global_path.resolve():
             project_mf = manifest.read_manifest(project_path)
 

--- a/src/napoln/core/hasher.py
+++ b/src/napoln/core/hasher.py
@@ -9,13 +9,15 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
+from napoln.core.home import NAPOLN_DIR
+
 
 def hash_skill(skill_dir: Path) -> str:
     """Hash a skill directory and return the first 7 hex chars of the SHA-256.
 
     The hash is computed over a deterministic concatenation:
         for each file (sorted by relative POSIX path, excluding .napoln):
-            relative_path \\x00 file_contents \\x00
+            relative_path \x00 file_contents \x00
 
     Args:
         skill_dir: Path to the skill directory.
@@ -25,11 +27,11 @@ def hash_skill(skill_dir: Path) -> str:
     """
     hasher = hashlib.sha256()
 
-    # Collect all files, excluding .napoln provenance
+    # Collect all files, excluding provenance files
     files = sorted(
         p.relative_to(skill_dir)
         for p in skill_dir.rglob("*")
-        if p.is_file() and p.name != ".napoln"
+        if p.is_file() and p.name != NAPOLN_DIR
     )
 
     for rel_path in files:
@@ -51,7 +53,7 @@ def hash_skill_full(skill_dir: Path) -> str:
     files = sorted(
         p.relative_to(skill_dir)
         for p in skill_dir.rglob("*")
-        if p.is_file() and p.name != ".napoln"
+        if p.is_file() and p.name != NAPOLN_DIR
     )
 
     for rel_path in files:

--- a/src/napoln/core/home.py
+++ b/src/napoln/core/home.py
@@ -10,6 +10,9 @@ import os
 from pathlib import Path
 
 
+NAPOLN_DIR = ".napoln"
+
+
 def get_napoln_home() -> Path:
     """Return the configured napoln home directory."""
-    return Path(os.environ.get("NAPOLN_HOME", Path.home() / ".napoln"))
+    return Path(os.environ.get("NAPOLN_HOME", Path.home() / NAPOLN_DIR))

--- a/src/napoln/core/linker.py
+++ b/src/napoln/core/linker.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from napoln.core.home import NAPOLN_DIR
+
 
 def _reflink_copy(src: Path, dst: Path) -> None:
     """Attempt a reflink (copy-on-write) clone of a single file."""
@@ -116,7 +118,7 @@ def write_provenance(
         f'installed = "{now}"\n'
         f'napoln_version = "{__version__}"\n'
     )
-    (target_dir / ".napoln").write_text(provenance)
+    (target_dir / NAPOLN_DIR).write_text(provenance)
 
 
 def restore_placement(

--- a/src/napoln/core/manifest.py
+++ b/src/napoln/core/manifest.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import tomli_w
 from pydantic import BaseModel, Field
 
+from napoln.core.home import NAPOLN_DIR
 from napoln.errors import ManifestError
 
 
@@ -264,5 +265,5 @@ def get_manifest_path(
         Path to the manifest.toml file.
     """
     if scope == "project" and project_root:
-        return project_root / ".napoln" / "manifest.toml"
+        return project_root / NAPOLN_DIR / "manifest.toml"
     return napoln_home / "manifest.toml"

--- a/src/napoln/core/merger.py
+++ b/src/napoln/core/merger.py
@@ -12,6 +12,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from napoln.core.home import NAPOLN_DIR
+
 
 def has_git() -> bool:
     """Check if git is available."""
@@ -143,7 +145,7 @@ def merge_skill(
     for d in [working_copy, store_base, store_new]:
         if d.exists():
             for f in d.rglob("*"):
-                if f.is_file() and f.name != ".napoln":
+                if f.is_file() and f.name != NAPOLN_DIR:
                     all_files.add(str(f.relative_to(d)))
 
     for rel_path in sorted(all_files):

--- a/src/napoln/core/store.py
+++ b/src/napoln/core/store.py
@@ -10,6 +10,7 @@ import shutil
 from pathlib import Path
 
 from napoln.core.hasher import hash_skill
+from napoln.core.home import NAPOLN_DIR
 from napoln.errors import StoreError
 
 
@@ -63,8 +64,8 @@ def store_skill(
             shutil.rmtree(temp_path)
         shutil.copytree(str(skill_dir), str(temp_path))
 
-        # Remove .napoln provenance if it was copied from a previous placement
-        napoln_file = temp_path / ".napoln"
+        # Remove provenance file if it was copied from a previous placement
+        napoln_file = temp_path / NAPOLN_DIR
         if napoln_file.exists():
             napoln_file.unlink()
 


### PR DESCRIPTION
Closes #58

Define NAPOLN_DIR = ".napoln" in core/home.py and replace all 6+ inline occurrences across core modules. Single point of change for the provenance directory name.