### PR TITLE
refactor: use output.py in list_cmd.py instead of importing typer directly

### DIFF
--- a/src/napoln/commands/list_cmd.py
+++ b/src/napoln/commands/list_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import typer
 from napoln import output
 from napoln.core import manifest
 from napoln.core.home import NAPOLN_DIR, get_napoln_home
@@ -95,8 +96,6 @@ def _print_skills(
     show_paths: bool = False,
 ) -> None:
     """Print skills from a manifest under a section label."""
-    import typer
-
     if not mf.skills:
         return
 
@@ -227,8 +226,6 @@ def run_list(
 
     if project_mf and project_mf.skills:
         if has_any:
-            import typer
-
             typer.echo()  # blank line between sections
         cwd_short = _abbreviate_path(str(Path.cwd()), str(Path.home()))
         project_label = f"Project ({cwd_short})"

--- a/src/napoln/output.py
+++ b/src/napoln/output.py
@@ -73,6 +73,11 @@ def print_json(data: Any) -> None:
     typer.echo(json.dumps(data, indent=2, default=str))
 
 
+def styled(message: str, **kwargs: Any) -> str:
+    """Return a styled string (pass through to typer.style)."""
+    return typer.style(message, **kwargs)
+
+
 def install_summary(
     skills: list[str],
     agent_names: list[str],


### PR DESCRIPTION
Closes #55

- Import typer at module level in list_cmd.py instead of inside functions
- Add output.styled() helper to output.py for reuse
- Use NAPOLN_DIR constant for project manifest path