### PR TITLE
refactor: move __version__ import to module level in linker.py

### DIFF
--- a/src/napoln/__init__.py
+++ b/src/napoln/__init__.py
@@ -1,3 +1,5 @@
 """napoln — A package manager for agent skills."""
 
-__version__ = "0.2.11"
+from napoln.core._version import __version__
+
+__all__ = ["__version__"]

--- a/src/napoln/core/_version.py
+++ b/src/napoln/core/_version.py
@@ -1,0 +1,3 @@
+"""Version number for napoln."""
+
+__version__ = "0.2.11"

--- a/src/napoln/core/linker.py
+++ b/src/napoln/core/linker.py
@@ -7,9 +7,11 @@ Fallback: full copy via shutil.copy2 if reflink is unavailable.
 from __future__ import annotations
 
 import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 
 from napoln.core.home import NAPOLN_DIR
+from napoln.core._version import __version__
 
 
 def _reflink_copy(src: Path, dst: Path) -> None:
@@ -104,11 +106,7 @@ def write_provenance(
     store_hash: str,
     link_mode: str,
 ) -> None:
-    """Write the .napoln provenance file to a placement."""
-    from datetime import datetime, timezone
-
-    from napoln import __version__
-
+    """Write the napoln provenance file to a placement."""
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     provenance = (
         f'source = "{source}"\n'


### PR DESCRIPTION
Closes #52

- Move __version__ to core/_version.py to break the import cycle
- linker.py now imports __version__ at module level from core/_version
- NAPOLN_DIR constant added to core/home.py (needed by linker.py)
- Reuse NAPOLN_DIR in linker.py write_provenance()