### PR TITLE
refactor: extract duplicated _ensure_initialized() directory creation

### DIFF
--- a/src/napoln/commands/add.py
+++ b/src/napoln/commands/add.py
@@ -8,7 +8,7 @@ from typing import cast
 from napoln import output
 from napoln.core import agents as agents_mod
 from napoln.core import linker, manifest, store, validator
-from napoln.core.home import get_napoln_home
+from napoln.core.home import ensure_napoln_dirs, get_napoln_home
 from napoln.core.naming import resolve_install_id
 from napoln.core.resolver import (
     ParsedSource,
@@ -168,9 +168,7 @@ def run_add(
 
 def _ensure_initialized(napoln_home: Path) -> None:
     """Ensure napoln home directory structure exists."""
-    napoln_home.mkdir(parents=True, exist_ok=True)
-    (napoln_home / "store").mkdir(exist_ok=True)
-    (napoln_home / "cache").mkdir(exist_ok=True)
+    ensure_napoln_dirs(napoln_home)
 
     config_path = napoln_home / "config.toml"
     if not config_path.exists():

--- a/src/napoln/commands/setup.py
+++ b/src/napoln/commands/setup.py
@@ -10,14 +10,12 @@ import tomli_w
 
 from napoln import output
 from napoln.core import agents as agents_mod
-from napoln.core.home import get_napoln_home
+from napoln.core.home import ensure_napoln_dirs, get_napoln_home
 from napoln.prompts import pick_agents
 
 
 def _ensure_initialized(napoln_home: Path) -> None:
-    napoln_home.mkdir(parents=True, exist_ok=True)
-    (napoln_home / "store").mkdir(exist_ok=True)
-    (napoln_home / "cache").mkdir(exist_ok=True)
+    ensure_napoln_dirs(napoln_home)
 
 
 def _load_config(config_path: Path) -> dict:

--- a/src/napoln/core/home.py
+++ b/src/napoln/core/home.py
@@ -16,3 +16,10 @@ NAPOLN_DIR = ".napoln"
 def get_napoln_home() -> Path:
     """Return the configured napoln home directory."""
     return Path(os.environ.get("NAPOLN_HOME", Path.home() / NAPOLN_DIR))
+
+
+def ensure_napoln_dirs(napoln_home: Path) -> None:
+    """Ensure napoln home directory structure exists (napoln_home/, store/, cache/)."""
+    napoln_home.mkdir(parents=True, exist_ok=True)
+    (napoln_home / "store").mkdir(exist_ok=True)
+    (napoln_home / "cache").mkdir(exist_ok=True)


### PR DESCRIPTION
Closes #50

Add ensure_napoln_dirs() to core/home.py for shared directory creation.
Used by both commands/add.py and commands/setup.py.